### PR TITLE
Use placeholder to replace string joining

### DIFF
--- a/lib/generators/social_share_button/templates/config/locales/social_share_button.en.yml
+++ b/lib/generators/social_share_button/templates/config/locales/social_share_button.en.yml
@@ -1,6 +1,6 @@
 en:
   social_share_button:
-    share_to: Share to
+    share_to: Share to %{name}
     weibo: Sina Weibo
     twitter: Twitter
     facebook: Facebook

--- a/lib/generators/social_share_button/templates/config/locales/social_share_button.zh-CN.yml
+++ b/lib/generators/social_share_button/templates/config/locales/social_share_button.zh-CN.yml
@@ -1,6 +1,6 @@
 'zh-CN':
   social_share_button:
-    share_to: 分享到
+    share_to: 分享到%{name}
     weibo: 新浪微博
     twitter: Twitter
     facebook: Facebook

--- a/lib/generators/social_share_button/templates/config/locales/social_share_button.zh-TW.yml
+++ b/lib/generators/social_share_button/templates/config/locales/social_share_button.zh-TW.yml
@@ -1,6 +1,6 @@
 'zh-TW':
   social_share_button:
-    share_to: 分享到
+    share_to: 分享到%{name}
     weibo: 新浪微博
     twitter: Twitter
     facebook: Facebook

--- a/lib/social_share_button/helper.rb
+++ b/lib/social_share_button/helper.rb
@@ -7,7 +7,7 @@ module SocialShareButton
       html << "<div class='social-share-button' data-title='#{title}' data-img='#{opts[:image]}'>"
       
       SocialShareButton.config.allow_sites.each do |name|
-        link_title = [t("social_share_button.share_to"),t("social_share_button.#{name.downcase}")].join("")
+        link_title = t "social_share_button.share_to", :name => t("social_share_button.#{name.downcase}")
         html << link_to("","#", :rel => "nofollow #{rel}", 
                         "data-site" => name, 
                         :class => "social-share-button-#{name}", 


### PR DESCRIPTION
From my experiences on several Rails i18n projects, we should use placeholder method if we need join some locale items to a string. e.g.  "分享到微博” , en:"Share to weibo", but for other language, it may be "xxxx weibo xxx".
