### PR TITLE
facebook share changes and twitter fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ For Popup window use this custom popup attribute:
 <%= social_share_button_tag(@post.title, :popup => "true")
 ```
 
+For Using Redirect URl use this custom redirect_url attribute:
+
+```erb
+<%= social_share_button_tag(@post.title, :redirect_url => "http://www.giveursite.com")
+```
+
 And you can custom rel attribute:
 
 ```erb
@@ -95,6 +101,11 @@ You can also specify the URL that it links to:
 <%= social_share_button_tag(@post.title, :url => "http://myapp.com/foo/bar", :image => "http://foo.bar/images/a.jpg", desc: "The summary of page") %>
 ```
 
+For the Facebook need to pass developer facebok_appid with custom attributes
+
+```erb
+<%= social_share_button_tag(@post.title, facebook_appid => "123434876786", :url => "http://myapp.com/foo/bar", :image => "http://foo.bar/images/a.jpg", desc: "The summary of page") %>
+```
 For the Tumblr there are an extra settings, prefixed with :'data-*'
 ```erb
 <%= social_share_button_tag(@post.title, :image => "https://raw.github.com/vkulpa/social-share-button/master/lib/assets/images/sprites/social-share-button/tumblr.png", :'data-type' => 'photo') %>

--- a/app/assets/javascripts/social-share-button.coffee
+++ b/app/assets/javascripts/social-share-button.coffee
@@ -16,7 +16,8 @@ window.SocialShareButton =
     via = encodeURIComponent($parent.data("via") || '')
     desc = encodeURIComponent($parent.data("desc") || ' ')
     popup = encodeURIComponent($parent.data("popup") || 'false')
-
+    facebook_appid = encodeURIComponent($parent.data("facebook_appid") || '')
+    redirect_uri = encodeURIComponent($parent.data("redirect_uri") || '')
     if url.length == 0
       url = encodeURIComponent(location.href)
     switch site
@@ -25,11 +26,11 @@ window.SocialShareButton =
       when "weibo"
         SocialShareButton.openUrl("http://service.weibo.com/share/share.php?url=#{url}&type=3&pic=#{img}&title=#{title}&appkey=#{appkey}",popup)
       when "twitter"
-        SocialShareButton.openUrl("https://twitter.com/intent/tweet?url=#{url}&text=#{title}&via=#{via}",popup)
+        SocialShareButton.openUrl("https://twitter.com/intent/tweet?url=#{url}&text=#{title}&via=#{via}&media=#{img}",popup)
       when "douban"
         SocialShareButton.openUrl("http://shuo.douban.com/!service/share?href=#{url}&name=#{title}&image=#{img}&sel=#{desc}",popup)
       when "facebook"
-        SocialShareButton.openUrl("http://www.facebook.com/sharer.php?u=#{url}",popup)
+        SocialShareButton.openUrl("https://www.facebook.com/dialog/feed?app_id=#{facebook_appid}&link=#{url}&picture=#{img}&redirect_uri=#{redirect_uri}&name=#{title}",popup)
       when "qq"
         SocialShareButton.openUrl("http://sns.qzone.qq.com/cgi-bin/qzshare/cgi_qzshare_onekey?url=#{url}&title=#{title}&pics=#{img}&summary=#{desc}&site=#{appkey}", popup)
       when "tqq"

--- a/lib/social_share_button/helper.rb
+++ b/lib/social_share_button/helper.rb
@@ -6,7 +6,8 @@ module SocialShareButton
       rel = opts[:rel]
       html = []
       html << "<div class='social-share-button' data-title='#{h title}' data-img='#{opts[:image]}'"
-      html << "data-url='#{opts[:url]}' data-desc='#{opts[:desc]}' data-popup='#{opts[:popup]}'>"
+      html << "data-url='#{opts[:url]}' data-desc='#{opts[:desc]}' data-popup='#{opts[:popup]}'"
+      html << "data-via='#{opts[:via]}' data-facebook_appid='#{opts[:facebook_appid]}' data-redirect_uri='#{opts[:redirect_uri]}' >"
       
       SocialShareButton.config.allow_sites.each do |name|
         extra_data = opts.select { |k, _| k.to_s.start_with?('data') } if name.eql?('tumblr')

--- a/lib/social_share_button/version.rb
+++ b/lib/social_share_button/version.rb
@@ -1,3 +1,3 @@
 module SocialShareButton
-  VERSION = "0.1.9"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
facebook deprecated share functionality it does only meta level image reading ang titles. 
facebook dialog feed supports same function it requires facbook appid. 
refer the link: https://developers.facebook.com/docs/sharing/reference/feed-dialog/v2.1  
issue no: #33 
Added twitter via and image sharing for twitter. #43 

Added redirect url for facebook. #28 
