### PR TITLE
Add `data-via` to allow `{ via: "MyTwitter" }`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ You can also specify the URL that it links to:
 
 
 ```erb
-<%= social_share_button_tag(@post.title, :url => "http://myapp.com/foo/bar", :image => "http://foo.bar/images/a.jpg", desc: "The summary of page") %>
+<%= social_share_button_tag(@post.title, :url => "http://myapp.com/foo/bar", :image => "http://foo.bar/images/a.jpg", desc: "The summary of page" via: "MyTwitterName") %>
 ```
 
 For the Tumblr there are an extra settings, prefixed with :'data-*'

--- a/lib/social_share_button/helper.rb
+++ b/lib/social_share_button/helper.rb
@@ -6,7 +6,7 @@ module SocialShareButton
       rel = opts[:rel]
       html = []
       html << "<div class='social-share-button' data-title='#{h title}' data-img='#{opts[:image]}'"
-      html << "data-url='#{opts[:url]}' data-desc='#{opts[:desc]}' data-popup='#{opts[:popup]}'>"
+      html << "data-url='#{opts[:url]}' data-desc='#{opts[:desc]}' data-popup='#{opts[:popup]}' data-via='#{opts[:via]}'>"
       
       SocialShareButton.config.allow_sites.each do |name|
         extra_data = opts.select { |k, _| k.to_s.start_with?('data') } if name.eql?('tumblr')


### PR DESCRIPTION
The helper is not utilizing the 'via' data attribute for Twitter which
is used within the Javascript.
