### PR TITLE
Add translation and FB.ui

### DIFF
--- a/app/assets/javascripts/social-share-button.coffee
+++ b/app/assets/javascripts/social-share-button.coffee
@@ -34,10 +34,9 @@ window.SocialShareButton =
           SocialShareButton.openUrl("http://www.facebook.com/sharer.php?u=#{url}", 555, 400)
         else
           FB.ui({
-            method: 'feed',
-            link: $parent.data("url"),
+            method: 'share',
+            href: $parent.data("url"),
             caption: $parent.data("title"),
-            display: 'popup',
             picture: $parent.data("img"),
             description: $parent.data("desk")
           })

--- a/app/assets/javascripts/social-share-button.coffee
+++ b/app/assets/javascripts/social-share-button.coffee
@@ -30,7 +30,17 @@ window.SocialShareButton =
       when "douban"
         SocialShareButton.openUrl("http://shuo.douban.com/!service/share?href=#{url}&name=#{title}&image=#{img}&sel=#{desc}", 770, 470)
       when "facebook"
-        SocialShareButton.openUrl("http://www.facebook.com/sharer.php?u=#{url}", 555, 400)
+        if FB == undefined # Without modern facebook JS plugin
+          SocialShareButton.openUrl("http://www.facebook.com/sharer.php?u=#{url}", 555, 400)
+        else
+          FB.ui({
+            method: 'feed',
+            link: $parent.data("url"),
+            caption: $parent.data("title"),
+            display: 'popup',
+            picture: $parent.data("img"),
+            description: $parent.data("desk")
+          })
       when "qq"
         SocialShareButton.openUrl("http://sns.qzone.qq.com/cgi-bin/qzshare/cgi_qzshare_onekey?url=#{url}&title=#{title}&pics=#{img}&summary=#{desc}&site=#{appkey}")
       when "google_plus"

--- a/lib/generators/social_share_button/templates/config/locales/social_share_button.fr.yml
+++ b/lib/generators/social_share_button/templates/config/locales/social_share_button.fr.yml
@@ -1,0 +1,17 @@
+fr:
+  social_share_button:
+    share_to: Partager sur %{name}
+    weibo: Sina Weibo
+    twitter: Twitter
+    facebook: Facebook
+    douban: Douban
+    qq: Qzone
+    delicious: Delicious
+    google_plus: Google+
+    google_bookmark: Google Bookmark
+    tumblr: Tumblr
+    pinterest: Pinterest
+    email: Email
+    linkedin: Linkedin
+    weichat: Weichat
+    vkontakte: Vkontakte

--- a/lib/social_share_button/version.rb
+++ b/lib/social_share_button/version.rb
@@ -1,3 +1,3 @@
 module SocialShareButton
-  VERSION = '0.3.2'
+  VERSION = '0.3.3'
 end


### PR DESCRIPTION
Add translation for "Share" in french and add support to FB.ui because Facebook Sharer is now deprecated, but let possibility to use both.