### PR TITLE
Encode wechat URL

### DIFF
--- a/app/assets/javascripts/social-share-button/wechat.coffee
+++ b/app/assets/javascripts/social-share-button/wechat.coffee
@@ -30,7 +30,7 @@ window.SocialShareWeChatButton =
      $wBody.qrcode
        width: 200
        height: 200
-       text: opts.url
+       text: decodeURIComponent(opts.url)
 
      $wContainer = $("#ss-wechat-dialog")
      top = ($(window).height() - $wContainer.height()) / 2


### PR DESCRIPTION
The purpose of this PR is to decode the url that apparently is passed as an encoded url.
If the url is encoded than Wechat "Scan QR Code" option cannot open the link correctly

![qrcode_fail](https://cloud.githubusercontent.com/assets/1397982/20451333/4872d374-adf8-11e6-90b0-a0de70c763b2.png)
