### PR TITLE
Fix single quotes being used for html tags. 

### DIFF
--- a/app/assets/javascripts/social-share-button.coffee
+++ b/app/assets/javascripts/social-share-button.coffee
@@ -13,6 +13,7 @@ window.SocialShareButton =
     title = encodeURIComponent($(el).data(site + '-title') || $parent.data('title') || '')
     img = encodeURIComponent($parent.data("img") || '')
     url = encodeURIComponent($parent.data("url") || '')
+    picture = encodeURIComponent($parent.data("og:image") || '')
     via = encodeURIComponent($parent.data("via") || '')
     desc = encodeURIComponent($parent.data("desc") || ' ')
 
@@ -36,7 +37,7 @@ window.SocialShareButton =
       when "douban"
         SocialShareButton.openUrl("http://shuo.douban.com/!service/share?href=#{url}&name=#{title}&image=#{img}&sel=#{desc}", 770, 470)
       when "facebook"
-        SocialShareButton.openUrl("http://www.facebook.com/sharer/sharer.php?u=#{url}&display=popup&title=#{title}&description=#{desc}", 555, 400)
+        SocialShareButton.openUrl("http://www.facebook.com/sharer/sharer.php?u=#{url}&display=popup&title=#{title}&description=#{desc}&picture=#{picture}", 555, 400)
       when "qq"
         SocialShareButton.openUrl("http://sns.qzone.qq.com/cgi-bin/qzshare/cgi_qzshare_onekey?url=#{url}&title=#{title}&pics=#{img}&summary=#{desc}&site=#{appkey}")
       when "google_plus"

--- a/lib/social_share_button/helper.rb
+++ b/lib/social_share_button/helper.rb
@@ -7,7 +7,7 @@ module SocialShareButton
       rel = opts[:rel]
       html = []
       html << "<div class=\"social-share-button\" data-title=\"#{h title}\" data-img=\"#{opts[:image]}\""
-      html << "data-url=\"#{opts[:url]}\" data-desc=\"#{opts[:desc]}\" data-via=\"#{opts[:via]}\">"
+      html << "data-url=\"#{opts[:url]}\" data-desc=\"#{opts[:desc]}\" data-via=\"#{opts[:via]}\" og:title=\"#{opts['og:title']}\" og:image=\"#{opts['og:image']}\" og:url=\"#{opts['og:url']}\"\\>"
 
       opts[:allow_sites].each do |name|
         extra_data = opts.select { |k, _| k.to_s.start_with?('data') } if name.eql?('tumblr')

--- a/lib/social_share_button/helper.rb
+++ b/lib/social_share_button/helper.rb
@@ -7,7 +7,7 @@ module SocialShareButton
       rel = opts[:rel]
       html = []
       html << "<div class=\"social-share-button\" data-title=\"#{h title}\" data-img=\"#{opts[:image]}\""
-      html << "data-url=\"#{opts[:url]}\" data-desc=\"#{opts[:desc]}\" data-via=\"#{opts[:via]}\" og:title=\"#{opts['og:title']}\" og:image=\"#{opts['og:image']}\" og:url=\"#{opts['og:url']}\"\\>"
+      html << "data-url=\"#{opts[:url]}\" data-desc=\"#{opts[:desc]}\" data-via=\"#{opts[:via]}\" og:title=\"#{h title}\" og:image=\"#{opts['og:image']}\" og:url=\"#{opts['og:url']}\"\\>"
 
       opts[:allow_sites].each do |name|
         extra_data = opts.select { |k, _| k.to_s.start_with?('data') } if name.eql?('tumblr')

--- a/lib/social_share_button/helper.rb
+++ b/lib/social_share_button/helper.rb
@@ -6,8 +6,8 @@ module SocialShareButton
       extra_data = {}
       rel = opts[:rel]
       html = []
-      html << "<div class='social-share-button' data-title='#{h title}' data-img='#{opts[:image]}'"
-      html << "data-url='#{opts[:url]}' data-desc='#{opts[:desc]}' data-via='#{opts[:via]}'>"
+      html << "<div class=\"social-share-button\" data-title=\"#{h title}\" data-img=\"#{opts[:image]}\""
+      html << "data-url=\"#{opts[:url]}\" data-desc=\"#{opts[:desc]}\" data-via=\"#{opts[:via]}\">"
 
       opts[:allow_sites].each do |name|
         extra_data = opts.select { |k, _| k.to_s.start_with?('data') } if name.eql?('tumblr')

--- a/lib/social_share_button/version.rb
+++ b/lib/social_share_button/version.rb
@@ -1,3 +1,3 @@
 module SocialShareButton
-  VERSION = '0.10.0'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
Common convention is to use double quotes as it maintains expected behavior.

I ran into an issue trying  to use this gem today:
```
        <%= social_share_button_tag("I got House #{@submitted_quiz.house.name.titleize}! What's yours?",
                                    url: @short_url,
                                    image: image_url(@submitted_quiz.house.image),
                                    desc: "To which house do you belong? To find out, it won't take long. Take this quiz and soon you'll see, all the fun that sorting can be!",
                                    'data-source': image_url(@submitted_quiz.house.image),
                                    'data-type': 'photo') %>
```

Generated:

```
<div class="social-share-button" data-title="I got House Raccoon! What's yours?" data-img="http://0.0.0.0:3000/assets/Raccoon-a6a6.png" data-url="http://short-url.com" data-desc="To which house do you belong? To find out, it won" t="" take="" long.="" this="" quiz="" and="" soon="" you'll="" see,="" all="" the="" fun="" that="" sorting="" can="" be!'="" data-via=""></div>
```

You can see everything went haywire after the first single quote in the word `won't`