### PR TITLE
fix translation_missing on WhatsApp button 

### DIFF
--- a/config/locales/social_share_button.de.yml
+++ b/config/locales/social_share_button.de.yml
@@ -21,4 +21,5 @@ de:
     reddit: Reddit
     hacker_news: Hacker News
     telegram: Telegram
-    whatsapp: WhatsApp
+    whatsapp_app: WhatsApp
+    whatsapp_web: WhatsApp

--- a/config/locales/social_share_button.en.yml
+++ b/config/locales/social_share_button.en.yml
@@ -21,4 +21,5 @@ en:
     reddit: Reddit
     hacker_news: Hacker News
     telegram: Telegram
-    whatsapp: WhatsApp
+    whatsapp_app: WhatsApp
+    whatsapp_web: WhatsApp

--- a/config/locales/social_share_button.es.yml
+++ b/config/locales/social_share_button.es.yml
@@ -21,4 +21,5 @@ es:
     reddit: Reddit
     hacker_news: Hacker News
     telegram: Telegram
-    whatsapp: WhatsApp
+    whatsapp_app: WhatsApp
+    whatsapp_web: WhatsApp

--- a/config/locales/social_share_button.fr.yml
+++ b/config/locales/social_share_button.fr.yml
@@ -21,4 +21,5 @@ fr:
     reddit: Reddit
     hacker_news: Hacker News
     telegram: Telegram
-    whatsapp: WhatsApp
+    whatsapp_app: WhatsApp
+    whatsapp_web: WhatsApp

--- a/config/locales/social_share_button.ja.yml
+++ b/config/locales/social_share_button.ja.yml
@@ -21,4 +21,5 @@ ja:
     reddit: Reddit
     hacker_news: Hacker News
     telegram: Telegram
-    whatsapp: WhatsApp
+    whatsapp_app: WhatsApp
+    whatsapp_web: WhatsApp

--- a/config/locales/social_share_button.pt-BR.yml
+++ b/config/locales/social_share_button.pt-BR.yml
@@ -21,4 +21,5 @@ en:
     reddit: Reddit
     hacker_news: Hacker News
     telegram: Telegram
-    whatsapp: WhatsApp
+    whatsapp_app: WhatsApp
+    whatsapp_web: WhatsApp

--- a/config/locales/social_share_button.ru.yml
+++ b/config/locales/social_share_button.ru.yml
@@ -21,4 +21,5 @@ ru:
     reddit: Reddit
     hacker_news: Hacker News
     telegram: Telegram
-    whatsapp: WhatsApp
+    whatsapp_app: WhatsApp
+    whatsapp_web: WhatsApp

--- a/config/locales/social_share_button.uk.yml
+++ b/config/locales/social_share_button.uk.yml
@@ -21,4 +21,5 @@ uk:
     reddit: Reddit
     hacker_news: Hacker News
     telegram: Telegram
-    whatsapp: WhatsApp
+    whatsapp_app: WhatsApp
+    whatsapp_web: WhatsApp

--- a/config/locales/social_share_button.zh-CN.yml
+++ b/config/locales/social_share_button.zh-CN.yml
@@ -21,4 +21,5 @@
     reddit: Reddit
     hacker_news: Hacker News
     telegram: Telegram
-    whatsapp: WhatsApp
+    whatsapp_app: WhatsApp
+    whatsapp_web: WhatsApp

--- a/config/locales/social_share_button.zh-TW.yml
+++ b/config/locales/social_share_button.zh-TW.yml
@@ -21,4 +21,5 @@
     reddit: Reddit
     hacker_news: Hacker News
     telegram: Telegram
-    whatsapp: WhatsApp
+    whatsapp_app: WhatsApp
+    whatsapp_web: WhatsApp


### PR DESCRIPTION
As now we have not only one WhatsApp, but two, one for mobile and one for web. 
We need whatsapp_app and whatsapp_web translations, as we add translated 'title' tag to html based on ["button tag"](https://github.com/huacnlee/social-share-button/blob/master/lib/social_share_button/helper.rb) name.
Which now is whatsapp_app or whatsapp_web, and not whatsapp.

