### PR TITLE
Fix WhatsApp url

### DIFF
--- a/app/assets/javascripts/social-share-button.coffee
+++ b/app/assets/javascripts/social-share-button.coffee
@@ -102,8 +102,8 @@ window.SocialShareButton =
       when "telegram"
         SocialShareButton.openUrl("https://telegram.me/share/url?text=#{title}&url=#{url}")
       when "whatsapp_app"
-        whatsapp_app_url = "whatsapp://send?text=#{title}&url=#{url}"
+        whatsapp_app_url = "whatsapp://send?text=#{title}%0A#{url}"
         window.open(whatsapp_app_url, '_top')
       when "whatsapp_web"
-        SocialShareButton.openUrl("https://web.whatsapp.com/send?text=#{title}&url=#{url}")
+        SocialShareButton.openUrl("https://web.whatsapp.com/send?text=#{title}%0A#{url}")
     false


### PR DESCRIPTION
As mentioned here https://github.com/huacnlee/social-share-button/pull/170#issuecomment-480562365 ,  including the URL as a query parameter doesn't work when sharing to WhatsApp.

This PR fixes that.

**Before picture**
![before](https://user-images.githubusercontent.com/40854305/64125827-bc136480-cdab-11e9-8e05-d91fdb042aa4.png)

**After picture**
![after](https://user-images.githubusercontent.com/40854305/64125814-adc54880-cdab-11e9-8d75-f3fa671f29e4.png)