### PR TITLE
Remove to param from email URL

### DIFF
--- a/app/assets/javascripts/social-share-button.coffee
+++ b/app/assets/javascripts/social-share-button.coffee
@@ -28,7 +28,7 @@ window.SocialShareButton =
       url = encodeURIComponent(location.href)
     switch site
       when "email"
-        location.href = "mailto:?to=&subject=#{title}&body=#{url}"
+        location.href = "mailto:?subject=#{title}&body=#{url}"
       when "weibo"
         SocialShareButton.openUrl("http://service.weibo.com/share/share.php?url=#{url}&type=3&pic=#{img}&title=#{title}&appkey=#{appkey}", 620, 370)
       when "twitter"


### PR DESCRIPTION
This is a small change to remove the empty `to` parameter from the email button URL. It caused the headers to get mangled in Outlook. Since it's empty (and the `to` parameter is usually specified in the path anyway), it shouldn't affect other clients.

Confirmed to work as expected in Outlook, Gmail, and MacOS Mail.